### PR TITLE
Fixed common device tree cloning

### DIFF
--- a/.github/workflows/Recovery Build.yml
+++ b/.github/workflows/Recovery Build.yml
@@ -94,6 +94,7 @@ jobs:
         github.event.inputs.COMMON_TREE_URL != null
         && github.event.inputs.COMMON_PATH != null
       run: |
+        cd ${{ steps.pwd.outputs.workspace-folder }}/fox_${{ github.event.inputs.MANIFEST_BRANCH }}
         git clone ${{ github.event.inputs.COMMON_TREE_URL }} -b ${{ github.event.inputs.DEVICE_TREE_BRANCH }} ./${{ github.event.inputs.COMMON_PATH }}
       working-directory: ${{ steps.pwd.outputs.workspace-folder }}
 


### PR DESCRIPTION
For some reason the common tree was cloned into a wrong directory, and was not detected by the builder. Fixed with a simple cd.